### PR TITLE
Fixes `DelayedHead` allowing odd numbers

### DIFF
--- a/src/PipeSys/Command/DelayedHead.php
+++ b/src/PipeSys/Command/DelayedHead.php
@@ -30,7 +30,7 @@ class DelayedHead extends AbstractCommand
 	 */
 	public function getCommand()
 	{
-		$delay = $this->lines / 2;
+		$delay = round($this->lines / 2);
 		while ($delay--)
 		{
 			yield true;


### PR DESCRIPTION
- Round the division, stupid mistake.
- Fixes #9.
