### PR TITLE
Commands EOF when reading from an invalid buffer.

### DIFF
--- a/src/PipeSys/Command/AbstractCommand.php
+++ b/src/PipeSys/Command/AbstractCommand.php
@@ -54,15 +54,7 @@ abstract class AbstractCommand implements CommandInterface
 			$firstRun = true;
 		}
 
-		try
-		{
-			return $this->attemptRun($firstRun);
-		}
-		catch (InvalidBufferException $e)
-		{
-			$this->invalidate();
-			return null;
-		}
+		return $this->attemptRun($firstRun);
 	}
 
 	/**
@@ -81,6 +73,11 @@ abstract class AbstractCommand implements CommandInterface
 		if ($this->isReading())
 		{
 			$data = $this->attemptRead();
+
+			if ($data instanceof EOF)
+			{
+				$this->invalidate();
+			}
 
 			if ($this->isReading())
 			{
@@ -155,7 +152,14 @@ abstract class AbstractCommand implements CommandInterface
 	{
 		if ($data instanceof OutputIntent)
 		{
-			$this->write($data->getChannel(), $data->getContent());
+			try
+			{
+				$this->write($data->getChannel(), $data->getContent());
+			}
+			catch (InvalidBufferException $e)
+			{
+				$this->invalidate();
+			}
 		}
 		if ($data instanceof ReadIntent)
 		{

--- a/src/PipeSys/Command/DelayedHead.php
+++ b/src/PipeSys/Command/DelayedHead.php
@@ -46,7 +46,5 @@ class DelayedHead extends AbstractCommand
 
 			yield new OutputIntent($input);
 		}
-
-		yield new OutputIntent(new EOF);
 	}
 }

--- a/src/PipeSys/Command/Sprunge.php
+++ b/src/PipeSys/Command/Sprunge.php
@@ -22,6 +22,7 @@ class Sprunge extends AbstractCommand
 	 */
 	public function getCommand()
 	{
+
 		while (true)
 		{
 			$input = (yield new ReadIntent);
@@ -34,9 +35,8 @@ class Sprunge extends AbstractCommand
 			$this->text .= $input;
 		}
 
-		$curl = curl_init();
+		$curl = curl_init('http://sprunge.us');
 
-		curl_setopt($curl, CURLOPT_URL, 'http://sprunge.us');
 		curl_setopt($curl, CURLOPT_POST, 1);
 		curl_setopt($curl, CURLOPT_POSTFIELDS, ['sprunge' => $this->text]);
 

--- a/src/PipeSys/IO/IOableTrait.php
+++ b/src/PipeSys/IO/IOableTrait.php
@@ -123,7 +123,14 @@ trait IOableTrait
 			throw new IOException("The IOableObject in position '$key' does not implement the InputInterface!");
 		}
 
-		return $this->ios[$key]['channel']->read();
+		try
+		{
+			return $this->ios[$key]['channel']->read();
+		}
+		catch (InvalidBufferException $e)
+		{
+			return new EOF;
+		}
 	}
 
 	/**

--- a/src/PipeSys/Scheduler.php
+++ b/src/PipeSys/Scheduler.php
@@ -57,7 +57,7 @@ class Scheduler
 			{
 				$result = $command->runOnce();
 
-				if ($result === null)
+				if ($result === null || ! $command->isValid())
 				{
 					unset($this->commands[$key]);
 				}


### PR DESCRIPTION
- Commands send EOF to their generator when they try to read from an invalid buffer.
  This allows commands to deal with the invalid buffer read and terminate properly.
  Commands like `Sprunge` rely on this sort of behaviour.
- Fixes #10.
