### PR TITLE
Fixes a bug whereby `0` is interpreted as falsy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /bin/sca/phpcs.txt
 /bin/sca/phpmd.html
 composer.lock
+/.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ language: php
 php:
   - '5.6'
   - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
+  - '7.4'
   - hhvm
   - nightly
-  
+
 before_install:
   - git config --global github.accesstoken $GITHUB_OAUTH_TOKEN
   - composer config github-oauth.github.com $GITHUB_OAUTH_TOKEN

--- a/bin/runtests.sh
+++ b/bin/runtests.sh
@@ -2,4 +2,4 @@
 
 BASEDIR=$(dirname $0)
 
-php BASEDIR/../tests/TestRig.php
+php $BASEDIR/../tests/TestRig.php

--- a/examples/LoopExample.php
+++ b/examples/LoopExample.php
@@ -1,0 +1,42 @@
+#!/usr/bin/env php
+<?php
+/**
+ * @title    Shows handling of falsy data such as `0` in a loop.
+ * @command  yes 0 | grep 0 | head
+ * @expected 0\n0\n0\n0\n0\n0\n0\n0\n0\n0\n
+ */
+
+error_reporting(E_ALL);
+
+include __DIR__ . '/../vendor/autoload.php';
+
+use ElvenSpellmaker\PipeSys as PS;
+use ElvenSpellmaker\PipeSys\Command as Command;
+use ElvenSpellmaker\PipeSys\IO as IO;
+
+class LoopSystem extends Command\AbstractCommand
+{
+	private $i = 5;
+
+	public function getCommand()
+	{
+		while($this->i--)
+		{
+			yield new IO\OutputIntent('0');
+			echo (yield new IO\ReadIntent), "\n";
+		}
+	}
+}
+
+$loopBuffer = new IO\QueueBuffer;
+
+$start = new LoopSystem;
+$end = new LoopSystem;
+
+$start->setStdIn($loopBuffer);
+$end->setStdOut($loopBuffer);
+
+$c = new PS\Scheduler(new Command\StandardConnector);
+$c->addCommand($start);
+$c->addCommand($end);
+$c->run();

--- a/src/PipeSys/Command/AbstractCommand.php
+++ b/src/PipeSys/Command/AbstractCommand.php
@@ -4,6 +4,7 @@ namespace ElvenSpellmaker\PipeSys\Command;
 
 use ElvenSpellmaker\PipeSys\Command\CommandInterface;
 use ElvenSpellmaker\PipeSys\IO\BufferInterface;
+use ElvenSpellmaker\PipeSys\IO\EOF;
 use ElvenSpellmaker\PipeSys\IO\InvalidBufferException;
 use ElvenSpellmaker\PipeSys\IO\IOableTrait;
 use ElvenSpellmaker\PipeSys\IO\OutputIntent;
@@ -89,7 +90,7 @@ abstract class AbstractCommand implements CommandInterface
 			$this->generator->next();
 		}
 
-		$genResponse = $data
+		$genResponse = $data !== null
 			? $this->generator->send($data)
 			: $this->generator->current();
 

--- a/src/PipeSys/IO/IOableTrait.php
+++ b/src/PipeSys/IO/IOableTrait.php
@@ -93,7 +93,7 @@ trait IOableTrait
 		{
 			$data = $this->read($this->readIntent->getChannel());
 
-			if ($data)
+			if ($data !== null)
 			{
 				$this->readIntent = null;
 			}

--- a/src/PipeSys/IO/QueueBuffer.php
+++ b/src/PipeSys/IO/QueueBuffer.php
@@ -98,7 +98,7 @@ class QueueBuffer implements BufferInterface
 		}
 		catch (RuntimeException $e)
 		{
-			return false;
+			return null;
 		}
 
 		if (isset($this->block))


### PR DESCRIPTION
  * Fixes a bug whereby an input of `0` wouldn't clear the buffer and
    wouldn't reset the `readIntent` status leading to pipelines
    potentially becoming completely blocked on reading
  * Changes a `false` to `null` in QueueBuffer
  * Adds all the new PHP 7 versions to the Travis build
  * Ignores the `.vscode` folder
  * Corrects build script (how was this working before???)
  * Adds a test to show the above behaviour is fixed